### PR TITLE
Bypass low target SDK version block on Android >= 14

### DIFF
--- a/android/src/main/kotlin/dev/re7gog/shizuku_apk_installer/ShizukuWizard.kt
+++ b/android/src/main/kotlin/dev/re7gog/shizuku_apk_installer/ShizukuWizard.kt
@@ -130,6 +130,9 @@ class ShizukuWizard(private val appContext: Context) {
         val params = PackageInstaller.SessionParams(PackageInstaller.SessionParams.MODE_FULL_INSTALL)
         var flags = Refine.unsafeCast<PackageInstallerHidden.SessionParamsHidden>(params).installFlags
         flags = flags or PackageManagerHidden.INSTALL_ALLOW_TEST or PackageManagerHidden.INSTALL_REPLACE_EXISTING
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            flags = flags or PackageManagerHidden.INSTALL_BYPASS_LOW_TARGET_SDK_BLOCK
+        }
         Refine.unsafeCast<PackageInstallerHidden.SessionParamsHidden>(params).installFlags = flags
         params
     }


### PR DESCRIPTION
[Starting from Android 14, apps that target SDK versions too old are blocked from being installed.](https://developer.android.com/about/versions/14/behavior-changes-all#minimum-target-api-level) Root and shell are allowed to bypass this limitation if [`INSTALL_BYPASS_LOW_TARGET_SDK_BLOCK` flag](https://android.googlesource.com/platform/frameworks/base/+/7c710f62228fbc829eaa097204a00bccd8aa420d%5E%21/#F0) is used.