### PR TITLE
Update HiddenApi stub to use `INSTALL_BYPASS_LOW_TARGET_SDK_BLOCK`

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -57,7 +57,7 @@ android {
         implementation("io.github.iamr0s:Dhizuku-API:2.5.3")
 
         implementation("dev.rikka.tools.refine:runtime:4.4.0")
-        compileOnly("dev.rikka.hidden:stub:4.3.2")
+        compileOnly("dev.rikka.hidden:stub:4.4.0")
         implementation("org.lsposed.hiddenapibypass:hiddenapibypass:4.3")
     }
 }

--- a/android/src/main/kotlin/dev/re7gog/shizuku_apk_installer/ShizukuWizard.kt
+++ b/android/src/main/kotlin/dev/re7gog/shizuku_apk_installer/ShizukuWizard.kt
@@ -194,7 +194,7 @@ class ShizukuWizard(private val appContext: Context) {
         flags = flags or PackageManagerHidden.INSTALL_ALLOW_TEST or PackageManagerHidden.INSTALL_REPLACE_EXISTING
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-            flags = flags or 0x01000000 // PackageManagerHidden.INSTALL_BYPASS_LOW_TARGET_SDK_BLOCK
+            flags = flags or PackageManagerHidden.INSTALL_BYPASS_LOW_TARGET_SDK_BLOCK
         }
 
         Refine.unsafeCast<PackageInstallerHidden.SessionParamsHidden>(params).installFlags = flags


### PR DESCRIPTION
The constant `PackageManagerHidden.INSTALL_BYPASS_LOW_TARGET_SDK_BLOCK` is only defined in `dev.rikka.hidden.stub` since [version 4.4.0](https://mvnrepository.com/artifact/dev.rikka.hidden/stub/4.4.0).

[`4.3.3..4.4.0` changes](https://github.com/RikkaW/HiddenApi/compare/5552dfe864e2e95e95fb18fc9cda272fac9bb6e9..28122e66c53752c3285dac52ade10b49fd8e0f11) include the [required change in the stub itself](https://github.com/RikkaW/HiddenApi/pull/7/files).

The build was broken previously by ["Bypass low target SDK version block on Android >= 14"](https://github.com/re7gog/shizuku_apk_installer/pull/1) as I was unaware of how hidden API and its refinement work. Sorry for breaking everyone's build...

With this pull request, it ***should*** work properly now.  
Before merging, it'll be safer if @ImranR98 can help test building Obtainium against this pull request. If that works correctly, [Obtainium#1669](https://github.com/ImranR98/Obtainium/issues/1669) — "Support for installing apk with target SDK lower then 23 (restriction in Android 14+)" will also be fixed.